### PR TITLE
Commandline publishing tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dsa_priv.pem
 *.perspectivev3
 *.pbxuser
 # Xcode 4
+DerivedData/
 xcuserdata/
 project.xcworkspace/
 # Generated files

--- a/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
+++ b/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
@@ -386,6 +386,12 @@
 		E3FEA8BB14E4989A00119FBE /* InspectorDegrees.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3FEA8BA14E4989900119FBE /* InspectorDegrees.xib */; };
 		E3FEA8BE14E498B700119FBE /* InspectorDegrees.m in Sources */ = {isa = PBXBuildFile; fileRef = E3FEA8BD14E498B700119FBE /* InspectorDegrees.m */; };
 		E3FEA8C014E49D8300119FBE /* InspectorInteger.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3FEA8BF14E49D8300119FBE /* InspectorInteger.xib */; };
+		FA98CFC4154E7D1C006E58C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA98CFC3154E7D1C006E58C5 /* Foundation.framework */; };
+		FA98CFC7154E7D1C006E58C5 /* ccbpublish.m in Sources */ = {isa = PBXBuildFile; fileRef = FA98CFC6154E7D1C006E58C5 /* ccbpublish.m */; };
+		FA98CFD1154E7F7D006E58C5 /* CCBX.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03614FB8A430078E771 /* CCBX.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FA98CFD7154E828E006E58C5 /* PlugInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B7AEDC14E3246100DFD402 /* PlugInManager.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FA98CFD9154E828E006E58C5 /* PlugInExport.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03214FB86D20078E771 /* PlugInExport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FA98CFDB154E8D16006E58C5 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA98CFDA154E8D16006E58C5 /* CoreServices.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1181,6 +1187,11 @@
 		E3FEA8BC14E498B600119FBE /* InspectorDegrees.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorDegrees.h; sourceTree = "<group>"; };
 		E3FEA8BD14E498B700119FBE /* InspectorDegrees.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InspectorDegrees.m; sourceTree = "<group>"; };
 		E3FEA8BF14E49D8300119FBE /* InspectorInteger.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InspectorInteger.xib; sourceTree = "<group>"; };
+		FA98CFC1154E7D1C006E58C5 /* ccbpublish */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ccbpublish; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA98CFC3154E7D1C006E58C5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		FA98CFC6154E7D1C006E58C5 /* ccbpublish.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ccbpublish.m; sourceTree = "<group>"; };
+		FA98CFC9154E7D1C006E58C5 /* ccbpublish-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ccbpublish-Prefix.pch"; sourceTree = "<group>"; };
+		FA98CFDA154E8D16006E58C5 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1324,6 +1335,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				E3FCE8671524856D0028E8E7 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA98CFBE154E7D1C006E58C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA98CFDB154E8D16006E58C5 /* CoreServices.framework in Frameworks */,
+				FA98CFC4154E7D1C006E58C5 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1561,6 +1581,7 @@
 		7789ABB3133AA82000CEFCC7 = {
 			isa = PBXGroup;
 			children = (
+				FA98CFDA154E8D16006E58C5 /* CoreServices.framework */,
 				E3D08A321524581100E55891 /* README.md */,
 				E3D59118150F50D1004180CA /* AUTHORS */,
 				E395DC7D1511FDF70075979E /* CHANGELOG */,
@@ -1573,6 +1594,7 @@
 				E3B7AED114E31A7800DFD402 /* PlugIns (Nodes) */,
 				E398C01D14FB813C0078E771 /* PlugIns (Exporters) */,
 				7789ABEF133AB17100CEFCC7 /* libs */,
+				FA98CFC5154E7D1C006E58C5 /* ccbpublish */,
 				7789ABC1133AA82000CEFCC7 /* Frameworks */,
 				7789ABBF133AA82000CEFCC7 /* Products */,
 			);
@@ -1598,6 +1620,7 @@
 				E3B84C39151A2C02004B743C /* CCControlButton.ccbPlugNode */,
 				E3C65116151BB89500D639C0 /* CCControl.ccbPlugNode */,
 				E3FCE8661524856D0028E8E7 /* CCScrollView.ccbPlugNode */,
+				FA98CFC1154E7D1C006E58C5 /* ccbpublish */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1610,6 +1633,7 @@
 				776A3713139590AA00960E94 /* ImageCaptureCore.framework */,
 				77D33E94138E714700012A88 /* ExceptionHandling.framework */,
 				7789ABC2133AA82000CEFCC7 /* Cocoa.framework */,
+				FA98CFC3154E7D1C006E58C5 /* Foundation.framework */,
 				7789ABC4133AA82000CEFCC7 /* Other Frameworks */,
 			);
 			name = Frameworks;
@@ -2627,6 +2651,23 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		FA98CFC5154E7D1C006E58C5 /* ccbpublish */ = {
+			isa = PBXGroup;
+			children = (
+				FA98CFC6154E7D1C006E58C5 /* ccbpublish.m */,
+				FA98CFC8154E7D1C006E58C5 /* Supporting Files */,
+			);
+			path = ccbpublish;
+			sourceTree = "<group>";
+		};
+		FA98CFC8154E7D1C006E58C5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				FA98CFC9154E7D1C006E58C5 /* ccbpublish-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2938,6 +2979,22 @@
 			productReference = E3FCE8661524856D0028E8E7 /* CCScrollView.ccbPlugNode */;
 			productType = "com.apple.product-type.bundle";
 		};
+		FA98CFC0154E7D1C006E58C5 /* ccbpublish */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA98CFCE154E7D1C006E58C5 /* Build configuration list for PBXNativeTarget "ccbpublish" */;
+			buildPhases = (
+				FA98CFBD154E7D1C006E58C5 /* Sources */,
+				FA98CFBE154E7D1C006E58C5 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ccbpublish;
+			productName = ccbpublish;
+			productReference = FA98CFC1154E7D1C006E58C5 /* ccbpublish */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2976,6 +3033,7 @@
 				E3B84C38151A2C02004B743C /* CCControlButton */,
 				E3FCE8651524856D0028E8E7 /* CCScrollView */,
 				7789ABBD133AA82000CEFCC7 /* CocosBuilder */,
+				FA98CFC0154E7D1C006E58C5 /* ccbpublish */,
 			);
 		};
 /* End PBXProject section */
@@ -3574,6 +3632,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA98CFBD154E7D1C006E58C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA98CFD7154E828E006E58C5 /* PlugInManager.m in Sources */,
+				FA98CFD9154E828E006E58C5 /* PlugInExport.m in Sources */,
+				FA98CFD1154E7F7D006E58C5 /* CCBX.m in Sources */,
+				FA98CFC7154E7D1C006E58C5 /* ccbpublish.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4706,6 +4775,58 @@
 			};
 			name = Release;
 		};
+		FA98CFCC154E7D1C006E58C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+					"\"$(SRCROOT)/libs\"",
+				);
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ccbpublish/ccbpublish-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"CC_DIRECTOR_MAC_THREAD=2",
+					NDEBUG,
+					NS_BLOCK_ASSERTIONS,
+					"CC_ENABLE_GL_STATE_CACHE=1",
+					"CCB_BUILDING_COMMANDLINE=1",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		FA98CFCD154E7D1C006E58C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)\"",
+					"\"$(SRCROOT)/libs\"",
+				);
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ccbpublish/ccbpublish-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"CC_DIRECTOR_MAC_THREAD=2",
+					NDEBUG,
+					NS_BLOCK_ASSERTIONS,
+					"CC_ENABLE_GL_STATE_CACHE=1",
+					"CCB_BUILDING_COMMANDLINE=1",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4870,6 +4991,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		FA98CFCE154E7D1C006E58C5 /* Build configuration list for PBXNativeTarget "ccbpublish" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA98CFCC154E7D1C006E58C5 /* Debug */,
+				FA98CFCD154E7D1C006E58C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CocosBuilder/ccBuilder/PlugInManager.h
+++ b/CocosBuilder/ccBuilder/PlugInManager.h
@@ -30,23 +30,30 @@
 
 @interface PlugInManager : NSObject
 {
+#if !CCB_BUILDING_COMMANDLINE
     NSMutableDictionary* plugInsNode;
     NSMutableArray* plugInsNodeNames;
     NSMutableArray* plugInsNodeNamesCanBeRoot;
-    
+#endif
+	
     NSMutableArray* plugInsExporters;
 }
 
+#if !CCB_BUILDING_COMMANDLINE
 @property (nonatomic,readonly) NSMutableArray* plugInsNodeNames;
 @property (nonatomic,readonly) NSMutableArray* plugInsNodeNamesCanBeRoot;
+#endif
+
 @property (nonatomic,retain) NSMutableArray* plugInsExporters;
 
 + (PlugInManager*) sharedManager;
 - (void) loadPlugIns;
 
+#if !CCB_BUILDING_COMMANDLINE
 // Plug-in node
 - (PlugInNode*) plugInNodeNamed:(NSString*)name;
 - (CCNode*) createDefaultNodeOfType:(NSString*)name;
+#endif
 
 // Plug-in export
 - (NSArray*) plugInsExportNames;

--- a/CocosBuilder/ccbpublish/ccbpublish-Prefix.pch
+++ b/CocosBuilder/ccbpublish/ccbpublish-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'ccbpublish' target in the 'ccbpublish' project
+//
+
+#ifdef __OBJC__
+	#import <Foundation/Foundation.h>
+#endif

--- a/CocosBuilder/ccbpublish/ccbpublish.m
+++ b/CocosBuilder/ccbpublish/ccbpublish.m
@@ -1,0 +1,179 @@
+/*
+ * CocosBuilder: http://www.cocosbuilder.com
+ *
+ * Copyright (c) 2012 Zynga Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "PlugInManager.h"
+#import "PlugInExport.h"
+
+static void	parseArgs(NSArray *args, NSString **outPlugin, NSArray **publishPaths, NSURL **outputPath, BOOL *verbose)
+{
+	*outPlugin = @"ccbi";
+	
+	NSMutableArray		*paths = [NSMutableArray array];
+	NSString			*prog = [args objectAtIndex:0];
+	BOOL				stillParsingArgs = YES;
+	
+	for (NSInteger i = 1; i < args.count; ++i)
+	{
+		NSString		*arg = [args objectAtIndex:i];
+		
+		if (stillParsingArgs && ([arg isEqualToString:@"-h"] || [arg isEqualToString:@"--help"]))
+		{
+			fprintf(stdout, "%s", [[NSString stringWithFormat:
+@"Usage:\n"
+@"%@ [-e <extension>|--extension=<extension>] [-o <outputfile>|--output=<outputfile>] [-v|--verbose] file\n"
+@"%@ [-e <extension>|--extension=<extension>] [-o <outputdir>|--output=<outputdir>] [-v|--verbose] file1 [file2 ...]\n"
+@"%@ -l|--list-available-plugins\n"
+@"%@ -h|--help\n"
+@"%@ --version\n", prog, prog, prog, prog, prog] UTF8String]);
+			exit(EXIT_SUCCESS);
+		}
+		else if (stillParsingArgs && [arg isEqualToString:@"--version"])
+		{
+			fprintf(stdout, "%s", [[NSString stringWithFormat:
+@"%@\n"
+@"Version %@\n", prog, @"1.1"] UTF8String]); // do not hardcode me
+			exit(EXIT_SUCCESS);
+		}
+		else if (stillParsingArgs && ([arg isEqualToString:@"-l"] || [arg isEqualToString:@"--list-available-plugins"]))
+		{
+			fprintf(stdout, "Available plugins:\n");
+			for (PlugInExport *plugin in [[PlugInManager sharedManager] plugInsExporters])
+				fprintf(stdout, "%s\n", [[NSString stringWithFormat:@"%@ - .%@", plugin.pluginName, plugin.extension] UTF8String]);
+			exit(EXIT_SUCCESS);
+		}
+		
+		else if (stillParsingArgs && ([arg isEqualToString:@"-v"] || [arg isEqualToString:@"--verbose"]))
+			*verbose = YES;
+
+		else if (stillParsingArgs && [arg isEqualToString:@"-e"])
+			*outPlugin = [args objectAtIndex:++i];
+		else if (stillParsingArgs && [arg hasPrefix:@"-e"])
+			*outPlugin = [arg substringFromIndex:2];
+		else if (stillParsingArgs && [arg hasPrefix:@"--extension="])
+			*outPlugin = [arg substringFromIndex:12];
+			
+		else if (stillParsingArgs && [arg isEqualToString:@"-o"])
+			*outputPath = [[NSURL fileURLWithPath:[args objectAtIndex:++i]] absoluteURL];
+		else if (stillParsingArgs && [arg hasPrefix:@"-o"])
+			*outputPath = [[NSURL fileURLWithPath:[arg substringFromIndex:2]] absoluteURL];
+		else if (stillParsingArgs && [arg hasPrefix:@"--output="])
+			*outputPath = [[NSURL fileURLWithPath:[arg substringFromIndex:9]] absoluteURL];
+
+		else if (stillParsingArgs && [arg isEqualToString:@"--"])
+			stillParsingArgs = NO;
+		else
+		{
+			stillParsingArgs = NO;
+			[paths addObject:[[NSURL fileURLWithPath:arg] absoluteURL]];
+		}
+	}
+	if ([paths count] < 1)
+	{
+		fprintf(stdout, "Error: Must provide at least one path to process.\n");
+		exit(EXIT_FAILURE);
+	}
+	*publishPaths = paths;
+}
+
+int		main(int argc, const char **argv)
+{
+	@autoreleasepool
+	{
+		NSMutableArray			*args = [NSMutableArray array];
+		
+		// It is trivially possible to get the OS to pass non-UTF-8 arguments,
+		//	but there is no immediate solution. For now, don't try to use this
+		//	with a non-Unicode terminal.
+		for (int i = 0; i < argc; ++i)
+			[args addObject:[NSString stringWithUTF8String:argv[i]]];
+		
+		NSString				*pluginExt = nil;
+		NSArray					*operands = nil;
+		NSURL					*outputPath = nil;
+		PlugInExport			*plugin = nil;
+		BOOL					verbose = NO;
+		
+		[[PlugInManager sharedManager] loadPlugIns];
+		parseArgs(args, &pluginExt, &operands, &outputPath, &verbose);
+		
+		if (!(plugin = [[PlugInManager sharedManager] plugInExportForExtension:pluginExt]))
+		{
+			fprintf(stdout, "Error: No plugin exists using the extension %s.\n", [pluginExt UTF8String]);
+			exit(EXIT_FAILURE);
+		}
+		
+		NSInteger				succeeds = 0, failures = 0;
+		
+		for (NSURL *file in operands)
+		{
+			NSDictionary		*dict = [NSDictionary dictionaryWithContentsOfURL:file];
+			
+			if (!dict)
+			{
+				++failures;
+				fprintf(stderr, "Error: Failed reading file %s.\n", [[file absoluteString] UTF8String]);
+				continue;
+			}
+			
+			NSData				*outData = [plugin exportDocument:dict];
+			
+			if (!outData)
+			{
+				++failures;
+				fprintf(stderr, "Error: Failed exporting file %s.\n", [[file absoluteString] UTF8String]);
+				continue;
+			}
+			
+			NSURL				*outFile = nil;
+			
+			if (outputPath == nil) // no output path and however many files: construct file name in file's dir
+				outFile = [[file URLByDeletingPathExtension] URLByAppendingPathExtension:plugin.extension];
+			else if (operands.count == 1) // output path and only one file: use output verbatim
+				outFile = outputPath;
+			else // output path and multiple files: use file's name in output path
+			{
+				outFile = [[[outputPath URLByAppendingPathComponent:file.lastPathComponent] URLByDeletingPathExtension]
+					URLByAppendingPathExtension:plugin.extension];
+			}
+			
+			if (![outData writeToURL:outFile options:NSDataWritingAtomic error:nil])
+			{
+				fprintf(stderr, "Error: Failed writing %s to %s.\n", [[file absoluteString] UTF8String], [[outFile absoluteString] UTF8String]);
+				++failures;
+			}
+			else
+			{
+				if (verbose)
+					fprintf(stderr, "Notice: Successfully processed %s.\n", [[file absoluteString] UTF8String]);
+				++succeeds;
+			}
+		}
+		
+		if (verbose)
+			fprintf(stderr, "Done processing. %ld files succeeded, %ld files failed.\n", succeeds, failures);
+		exit(failures ? EXIT_FAILURE : EXIT_SUCCESS);
+	}
+	return 0;
+}


### PR DESCRIPTION
While working on a new project, I thought it would be convenient to be able to add `.ccb` files directly in Xcode and compile them to `.ccbi`s as a build rule, so I added a target which builds a `ccbpublish` tool using the export plugins from the main app. It relies on Launch Services to find the app and its plugins.

Known issues:
- It doesn't honor the flatten paths setting
- The commandline argument parser is very primitive (probably should've used `getopt`)
- The app's bundle ID is hardcoded.
- The default plugin if none is specified should probably be the first one loaded instead of hardcoding `ccbi`
- Confusingly, unlike everything else, it uses ARC (but no weak references, so will work on 10.6)
