### PR TITLE
No ARC for commandline tool.

### DIFF
--- a/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
+++ b/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
@@ -388,9 +388,9 @@
 		E3FEA8C014E49D8300119FBE /* InspectorInteger.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3FEA8BF14E49D8300119FBE /* InspectorInteger.xib */; };
 		FA98CFC4154E7D1C006E58C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA98CFC3154E7D1C006E58C5 /* Foundation.framework */; };
 		FA98CFC7154E7D1C006E58C5 /* ccbpublish.m in Sources */ = {isa = PBXBuildFile; fileRef = FA98CFC6154E7D1C006E58C5 /* ccbpublish.m */; };
-		FA98CFD1154E7F7D006E58C5 /* CCBX.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03614FB8A430078E771 /* CCBX.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FA98CFD7154E828E006E58C5 /* PlugInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B7AEDC14E3246100DFD402 /* PlugInManager.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		FA98CFD9154E828E006E58C5 /* PlugInExport.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03214FB86D20078E771 /* PlugInExport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		FA98CFD1154E7F7D006E58C5 /* CCBX.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03614FB8A430078E771 /* CCBX.m */; };
+		FA98CFD7154E828E006E58C5 /* PlugInManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E3B7AEDC14E3246100DFD402 /* PlugInManager.m */; };
+		FA98CFD9154E828E006E58C5 /* PlugInExport.m in Sources */ = {isa = PBXBuildFile; fileRef = E398C03214FB86D20078E771 /* PlugInExport.m */; };
 		FA98CFDB154E8D16006E58C5 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA98CFDA154E8D16006E58C5 /* CoreServices.framework */; };
 /* End PBXBuildFile section */
 
@@ -4779,7 +4779,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4805,7 +4804,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4999,6 +4997,7 @@
 				FA98CFCD154E7D1C006E58C5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CocosBuilder/ccbpublish/ccbpublish.m
+++ b/CocosBuilder/ccbpublish/ccbpublish.m
@@ -99,7 +99,11 @@ static void	parseArgs(NSArray *args, NSString **outPlugin, NSArray **publishPath
 
 int		main(int argc, const char **argv)
 {
+#if __clang_major__ >= 3
 	@autoreleasepool
+#else
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+#endif
 	{
 		NSMutableArray			*args = [NSMutableArray array];
 		
@@ -175,5 +179,8 @@ int		main(int argc, const char **argv)
 			fprintf(stderr, "Done processing. %ld files succeeded, %ld files failed.\n", succeeds, failures);
 		exit(failures ? EXIT_FAILURE : EXIT_SUCCESS);
 	}
+#if __clang_major__ < 3
+	[pool drain];
+#endif
 	return 0;
 }


### PR DESCRIPTION
As it turns out, getting rid of ARC was just a matter of turning off the flag. I also switched over to `NSAutoreleasePool` for old versions of Clang, which I think should fix building on Snow Leopard.
