### PR TITLE
Linked "Help" to online user guide

### DIFF
--- a/CocosBuilder/ccBuilder/CocosBuilderAppDelegate.m
+++ b/CocosBuilder/ccBuilder/CocosBuilderAppDelegate.m
@@ -2012,6 +2012,13 @@
     }
 }
 
+- (IBAction)showHelp:(id)sender
+{
+    NSURL* url = [NSURL URLWithString:@"http://cocosbuilder.com/?page_id=68"];
+    
+    [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
 #pragma mark Debug
 
 - (IBAction) debug:(id)sender


### PR DESCRIPTION
This eliminates the "there is no help" default dialog and points to
something useful
