### PR TITLE
Fixed leaked node created by CCBReader.

### DIFF
--- a/CocosBuilderExample/CocosBuilderExample/CCBReader.m
+++ b/CocosBuilderExample/CocosBuilderExample/CCBReader.m
@@ -769,7 +769,7 @@
     CCNode* node = [[[class alloc] init] autorelease];
     
     // Set root node
-    if (!actionManager.rootNode) actionManager.rootNode = [node retain];
+    if (!actionManager.rootNode) actionManager.rootNode = node;
     
     // Read animated properties
     NSMutableDictionary* seqs = [NSMutableDictionary dictionary];


### PR DESCRIPTION
I noticed that all my root nodes created by CCBReader were staying alive forever.  This commit should fix it.
