### PR TITLE
Fixed markdown errors

### DIFF
--- a/Documentation/1. User Guide.md
+++ b/Documentation/1. User Guide.md
@@ -57,7 +57,7 @@ By default, CocosBuilder is set up to compile and copy your ccb-files and your r
 You have the option to publish to a zip file. If this option is used a zip file called ccb.zip will be placed in your destination directory. To be able to load the zip-file in your code you need to:
 
 1. Include the SSZipArchive classes, in addition to the CCBReader, in your Xcode project.
-2. In your project's build settings, add CCB_ENABLE_UNZIP to your _Preprocessor Macros_.
+2. In your project's build settings, add CCB\_ENABLE\_UNZIP to your _Preprocessor Macros_.
 3. Replace cocos2d's default CCFileUtils class by calling [CCBFileUtils sharedFileUtils] before your cocos2d is loaded (you will need to import CCBReader.h to do this).
 4. Unpack the zip file by calling [CCBReader unzipResources:@"ccb.zip"]
 


### PR DESCRIPTION
Fixed CCB_ENABLE_UNZIP because of unnecessary Markdown.
