### PR TITLE
fix for crash while publishing - baseValue in case of SpriteFrame was not cached

### DIFF
--- a/CocosBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.m
+++ b/CocosBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.m
@@ -467,6 +467,42 @@
         
         NSString* type = [prop objectForKey:@"type"];
         
+        id baseValue = [prop objectForKey:@"baseValue"];
+        
+        if (baseValue)
+        {
+            // We need to transform the base value to a normal value (base values override normal values)
+            if ([type isEqualToString:@"Position"])
+            {
+                value = [NSArray arrayWithObjects:
+                         [baseValue objectAtIndex:0],
+                         [baseValue objectAtIndex:1],
+                         [value objectAtIndex:2],
+                         nil];
+            }
+            else if ([type isEqualToString:@"ScaleLock"])
+            {
+                value = [NSArray arrayWithObjects:
+                         [baseValue objectAtIndex:0],
+                         [baseValue objectAtIndex:1],
+                         [NSNumber numberWithBool:NO],
+                         [value objectAtIndex:3],
+                         nil];
+            }
+            else if ([type isEqualToString:@"SpriteFrame"])
+            {
+                NSString* a = [baseValue objectAtIndex:0];
+                NSString* b = [baseValue objectAtIndex:1];
+                if ([b isEqualToString:@"Use regular file"]) b = @"";
+                value = [NSArray arrayWithObjects:b, a, nil];
+            }
+            else
+            {
+                // Value needs no transformation
+                value = baseValue;
+            }
+        }
+        
         if ([type isEqualToString:@"SpriteFrame"])
         {
             NSString* a = [value objectAtIndex:0];


### PR DESCRIPTION
The application was crashing when exporting ccb which has sprite frame. The possible reason was that image name is not cached when used in baseValue. After adding the special handling of baseValue in CCBXCocos2diPhoneWriter.cacheStringsForNode it seems to work ok.
