### PR TITLE
Added support for audio files in ResourceManager

### DIFF
--- a/CocosBuilder/ccBuilder/CCBPublisher.m
+++ b/CocosBuilder/ccBuilder/CCBPublisher.m
@@ -58,7 +58,7 @@
     }
     
     // Setup extensions to copy
-    copyExtensions = [[NSArray alloc] initWithObjects:@"jpg",@"png", @"pvr", @"ccz", @"plist", @"fnt", @"ttf",@"js", nil];
+    copyExtensions = [[NSArray alloc] initWithObjects:@"jpg",@"png", @"pvr", @"ccz", @"plist", @"fnt", @"ttf",@"js",@"wav",@"mp3",@"m4a",@"caf", nil];
     
     // Set format to use for exports
     self.publishFormat = projectSettings.exporter;

--- a/CocosBuilder/ccBuilder/ResourceManager.h
+++ b/CocosBuilder/ccBuilder/ResourceManager.h
@@ -38,7 +38,8 @@ enum
     kCCBResTypeBMFont,
     kCCBResTypeTTF,
     kCCBResTypeCCBFile,
-    kCCBResTypeJS
+    kCCBResTypeJS,
+    kCCBResTypeAudio    
 };
 
 
@@ -94,6 +95,7 @@ enum
     NSMutableArray* bmFonts;
     NSMutableArray* ttfFonts;
     NSMutableArray* ccbFiles;
+    NSMutableArray* audioFiles;
 }
 
 @property (nonatomic,assign) int count;
@@ -105,6 +107,7 @@ enum
 @property (nonatomic,readonly) NSMutableArray* bmFonts;
 @property (nonatomic,readonly) NSMutableArray* ttfFonts;
 @property (nonatomic,readonly) NSMutableArray* ccbFiles;
+@property (nonatomic,readonly) NSMutableArray* audioFiles;
 - (NSArray*) resourcesForType:(int)type;
 
 @end

--- a/CocosBuilder/ccBuilder/ResourceManager.m
+++ b/CocosBuilder/ccBuilder/ResourceManager.m
@@ -166,6 +166,7 @@
 @synthesize bmFonts;
 @synthesize ttfFonts;
 @synthesize ccbFiles;
+@synthesize audioFiles;
 
 - (id) init
 {
@@ -179,6 +180,7 @@
     bmFonts = [[NSMutableArray alloc] init];
     ttfFonts = [[NSMutableArray alloc] init];
     ccbFiles = [[NSMutableArray alloc] init];
+    audioFiles = [[NSMutableArray alloc] init];
     
     return self;
 }
@@ -191,6 +193,7 @@
     if (type == kCCBResTypeTTF) return ttfFonts;
     if (type == kCCBResTypeAnimation) return animations;
     if (type == kCCBResTypeCCBFile) return ccbFiles;
+    if (type == kCCBResTypeAudio) return audioFiles;
     return NULL;
 }
 
@@ -203,6 +206,7 @@
     [bmFonts release];
     [ttfFonts release];
     [ccbFiles release];
+    [audioFiles release];
     self.dirPath = NULL;
     [super dealloc];
 }
@@ -389,7 +393,13 @@
     {
         return kCCBResTypeJS;
     }
-    
+    else if ([ext isEqualToString:@"wav"]
+             || [ext isEqualToString:@"mp3"]
+             || [ext isEqualToString:@"m4a"]
+             || [ext isEqualToString:@"caf"])
+    {
+        return kCCBResTypeAudio;
+    }
     return kCCBResTypeNone;
 }
 
@@ -506,6 +516,7 @@
         [dir.bmFonts removeAllObjects];
         [dir.ttfFonts removeAllObjects];
         [dir.ccbFiles removeAllObjects];
+        [dir.audioFiles removeAllObjects];
         
         for (NSString* file in resources)
         {
@@ -537,6 +548,12 @@
                 [dir.ccbFiles addObject:res];
                 
             }
+            if (res.type == kCCBResTypeAudio
+                || res.type == kCCBResTypeDirectory)
+            {
+                [dir.audioFiles addObject:res];
+                
+            }
             if (res.type == kCCBResTypeImage
                 || res.type == kCCBResTypeSpriteSheet
                 || res.type == kCCBResTypeAnimation
@@ -544,7 +561,8 @@
                 || res.type == kCCBResTypeTTF
                 || res.type == kCCBResTypeCCBFile
                 || res.type == kCCBResTypeDirectory
-                || res.type == kCCBResTypeJS)
+                || res.type == kCCBResTypeJS
+                || res.type == kCCBResTypeAudio)
             {
                 [dir.any addObject:res];
             }
@@ -556,6 +574,7 @@
         [dir.bmFonts sortUsingSelector:@selector(compare:)];
         [dir.ttfFonts sortUsingSelector:@selector(compare:)];
         [dir.ccbFiles sortUsingSelector:@selector(compare:)];
+        [dir.audioFiles sortUsingSelector:@selector(compare:)];
     }
     
     if (resourcesChanged) [self notifyResourceObserversResourceListUpdated];

--- a/CocosBuilder/ccBuilder/ResourceManagerOutlineHandler.m
+++ b/CocosBuilder/ccBuilder/ResourceManagerOutlineHandler.m
@@ -265,6 +265,7 @@
     NSString* spriteFile = NULL;
     NSString* spriteSheetFile = NULL;
     NSString* ccbFile = NULL;
+    NSString* audioFile = NULL;
     
     for (id item in items)
     {
@@ -278,6 +279,10 @@
             else if (res.type == kCCBResTypeCCBFile)
             {
                 ccbFile = [ResourceManagerUtil relativePathFromAbsolutePath: res.filePath];
+            }
+            else if (res.type == kCCBResTypeAudio)
+            {
+                audioFile = [ResourceManagerUtil relativePathFromAbsolutePath: res.filePath];
             }
         }
         else if ([item isKindOfClass:[RMSpriteFrame class]])
@@ -313,6 +318,17 @@
         NSData* clipData = [NSKeyedArchiver archivedDataWithRootObject:clipDict];
         [pasteboard declareTypes:[NSArray arrayWithObject:@"com.cocosbuilder.ccb"] owner:NULL];
         [pasteboard setData:clipData forType:@"com.cocosbuilder.ccb"];
+        
+        return YES;
+    }
+    else if (audioFile)
+    {
+        NSMutableDictionary* clipDict = [NSMutableDictionary dictionary];
+        [clipDict setObject:audioFile forKey:@"audioFile"];
+        
+        NSData* clipData = [NSKeyedArchiver archivedDataWithRootObject:clipDict];
+        [pasteboard declareTypes:[NSArray arrayWithObject:@"com.cocosbuilder.audio"] owner:NULL];
+        [pasteboard setData:clipData forType:@"com.cocosbuilder.audio"];
         
         return YES;
     }

--- a/CocosBuilder/ccBuilder/ResourceManagerUtil.m
+++ b/CocosBuilder/ccBuilder/ResourceManagerUtil.m
@@ -72,7 +72,8 @@
             if (res.type == kCCBResTypeImage
                 || res.type == kCCBResTypeBMFont
                 || res.type == kCCBResTypeCCBFile
-                || res.type == kCCBResTypeTTF)
+                || res.type == kCCBResTypeTTF
+                || res.type == kCCBResTypeAudio)
             {
                 NSString* itemName = [res.filePath lastPathComponent];
                 NSMenuItem* menuItem = [[[NSMenuItem alloc] initWithTitle:itemName action:@selector(selectedResource:) keyEquivalent:@""] autorelease];


### PR DESCRIPTION
Minor addition to CocosBulder ResourceManager, to display audio files.

Audio files are also exported by  CCBPublisher.

Supported audio file extensions are:
wav
mp3
m4a
caf

Finally, when dragging an audio file, the filename is copied to PasteBoard for future use. Type of clipped data is com.cocosbuilder.audio
