### PR TITLE
Fixes application crash during resolution switching/editing

### DIFF
--- a/CocosBuilder/ccBuilder/CocosBuilderAppDelegate.m
+++ b/CocosBuilder/ccBuilder/CocosBuilderAppDelegate.m
@@ -2308,12 +2308,15 @@ static BOOL hideAllToNextSeparator;
 
 - (void) setResolution:(int)r
 {
-    CocosScene* cs = [CocosScene cocosScene];
     
-    ResolutionSetting* resolution = [currentDocument.resolutions objectAtIndex:r];
     currentDocument.currentResolution = r;
     
-    [cs setStageSize:CGSizeMake(resolution.width, resolution.height) centeredOrigin:[cs centeredOrigin]];
+    //
+    // No need to call setStageSize here, since it gets called from reloadResources
+    //
+    //CocosScene* cs = [CocosScene cocosScene];
+    //ResolutionSetting* resolution = [currentDocument.resolutions objectAtIndex:r];
+    //[cs setStageSize:CGSizeMake(resolution.width, resolution.height) centeredOrigin:[cs centeredOrigin]];
     
     [self updateResolutionMenu];
     [self reloadResources];

--- a/CocosBuilder/ccBuilder/CocosScene.m
+++ b/CocosBuilder/ccBuilder/CocosScene.m
@@ -274,11 +274,13 @@ static CocosScene* sharedCocosScene;
 
 - (void) setStageSize: (CGSize) size centeredOrigin:(BOOL)centeredOrigin
 {
+    
     stageBgLayer.contentSize = size;
     if (centeredOrigin) contentLayer.position = ccp(size.width/2, size.height/2);
     else contentLayer.position = ccp(0,0);
     
     [self setStageBorder:stageBorderType];
+    
     
     if (renderedScene)
     {
@@ -288,10 +290,18 @@ static CocosScene* sharedCocosScene;
     
     if (size.width > 0 && size.height > 0 && size.width <= 1024 && size.height <= 1024)
     {
+        // Use a new autorelease pool
+        // Otherwise, two successive calls to the running method (_cmd) cause a crash!
+        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+        
         renderedScene = [CCRenderTexture renderTextureWithWidth:size.width height:size.height];
         renderedScene.anchorPoint = ccp(0.5f,0.5f);
         [self addChild:renderedScene];
+
+        [pool drain];
     }
+    
+    
 }
 
 - (CGSize) stageSize


### PR DESCRIPTION
Main fix: Add a new autorelease pool when creating the new RenderTexture.

Performance fix: remove duplicate method call "setStageSize", since it gets called later in the code from "reloadResources".
