### PR TITLE
Feature/Fix: Plugin property type "Check" is no more bound to CCNode's visible property

### DIFF
--- a/CocosBuilder/CCNode/CCBPProperties.plist
+++ b/CocosBuilder/CCNode/CCBPProperties.plist
@@ -30,6 +30,18 @@
 			<string>CCNode</string>
 		</dict>
 		<dict>
+			<key>animatable</key>
+			<true/>
+			<key>defaultSerialization</key>
+			<true/>
+			<key>type</key>
+			<string>Check</string>
+			<key>name</key>
+			<string>visible</string>
+			<key>displayName</key>
+			<string>Visible</string>
+		</dict>
+		<dict>
 			<key>defaultSerialization</key>
 			<array>
 				<integer>0</integer>
@@ -117,16 +129,6 @@
 			<string>ignoreAnchorPointForPosition</string>
 			<key>displayName</key>
 			<string>Ignore anchor point</string>
-		</dict>
-		<dict>
-			<key>defaultSerialization</key>
-			<true/>
-			<key>type</key>
-			<string>Check</string>
-			<key>name</key>
-			<string>visible</string>
-			<key>displayName</key>
-			<string>Visible</string>
 		</dict>
 	</array>
 	<key>propertiesOverridden</key>

--- a/CocosBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.m
+++ b/CocosBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.m
@@ -767,7 +767,7 @@
             // Write property type
             int kfType = [[prop objectForKey:@"type"] intValue];
             NSString* propType = NULL;
-            if (kfType == kCCBKeyframeTypeVisible) propType = @"Check";
+            if (kfType == kCCBKeyframeTypeToggle) propType = @"Check";
             else if (kfType == kCCBKeyframeTypeByte) propType = @"Byte";
             else if (kfType == kCCBKeyframeTypeColor3) propType = @"Color3";
             else if (kfType == kCCBKeyframeTypeDegrees) propType = @"Degrees";
@@ -782,7 +782,7 @@
             // Write number of keyframes
             NSArray* keyframes = [prop objectForKey:@"keyframes"];
             
-            if (kfType == kCCBKeyframeTypeVisible && keyframes.count > 0)
+            if (kfType == kCCBKeyframeTypeToggle && keyframes.count > 0)
             {
                 BOOL visible = YES;
                 NSDictionary* keyframeFirst = [keyframes objectAtIndex:0];

--- a/CocosBuilder/ccBuilder/CCNode+NodeInfo.m
+++ b/CocosBuilder/ccBuilder/CCNode+NodeInfo.m
@@ -168,8 +168,7 @@
     }
     
     // Ensure that the keyframe type is animated
-    if (![self.plugIn.animatableProperties containsObject:name]
-        && ![name isEqualToString:@"visible"])
+    if (![self.plugIn.animatableProperties containsObject:name])
     {
         return;
     }
@@ -188,9 +187,9 @@
         keyframe.easing.type = kCCBKeyframeEasingInstant;
     }
     
-    if (keyframeType == kCCBKeyframeTypeVisible)
+    if (keyframeType == kCCBKeyframeTypeToggle)
     {
-        // Values for visiblity keyframes are ignored (each keyframe toggles the state)
+        // Values for toggle keyframes are ignored (each keyframe toggles the state)
         keyframe.value = [NSNumber numberWithBool:YES];
     }
     else
@@ -278,9 +277,9 @@
                 [NSNumber numberWithFloat:y],
                 nil];
     }
-    else if (type == kCCBKeyframeTypeVisible)
+    else if (type == kCCBKeyframeTypeToggle)
     {
-        return [self valueForKey:@"visible"];
+        return [self valueForKey:name];
     }
     else if (type == kCCBKeyframeTypeColor3)
     {
@@ -329,7 +328,7 @@
         
         [PositionPropertySetter setScaledX:x Y:y type:type forNode:self prop:propName];
     }
-    else if (type == kCCBKeyframeTypeVisible)
+    else if (type == kCCBKeyframeTypeToggle)
     {
         [self setValue:value forKey:propName];
     }
@@ -355,7 +354,7 @@
 
 - (void) updatePropertiesTime:(float)time sequenceId:(int)seqId
 {
-    [self updateProperty:@"visible" time:time sequenceId:seqId];
+
     
     NSArray* animatableProps = [self.plugIn animatableProperties];
     for (NSString* propName in animatableProps)

--- a/CocosBuilder/ccBuilder/SequencerHandler.m
+++ b/CocosBuilder/ccBuilder/SequencerHandler.m
@@ -431,7 +431,7 @@ static SequencerHandler* sharedSequencerHandler;
     CCNode* node = item;
     if (node.seqExpanded)
     {
-        return kCCBSeqDefaultRowHeight * ([node.plugIn.animatableProperties count] + 1);
+        return kCCBSeqDefaultRowHeight * ([node.plugIn.animatableProperties count]);
     }
     else
     {
@@ -724,7 +724,7 @@ static SequencerHandler* sharedSequencerHandler;
     
     if ([node shouldDisableProperty:prop]) return NO;
     
-    if ([prop isEqualToString:@"visible"]) return YES;
+
     return [node.plugIn.animatableProperties containsObject:prop];
 }
 

--- a/CocosBuilder/ccBuilder/SequencerKeyframe.h
+++ b/CocosBuilder/ccBuilder/SequencerKeyframe.h
@@ -30,7 +30,7 @@
 enum
 {
     kCCBKeyframeTypeUndefined,
-    kCCBKeyframeTypeVisible,
+    kCCBKeyframeTypeToggle,
     kCCBKeyframeTypeDegrees,
     kCCBKeyframeTypePosition,
     kCCBKeyframeTypeScaleLock,

--- a/CocosBuilder/ccBuilder/SequencerKeyframe.m
+++ b/CocosBuilder/ccBuilder/SequencerKeyframe.m
@@ -92,7 +92,7 @@
     }
     else if ([type isEqualToString:@"Check"])
     {
-        return kCCBKeyframeTypeVisible;
+        return kCCBKeyframeTypeToggle;
     }
     else if ([type isEqualToString:@"Byte"])
     {

--- a/CocosBuilder/ccBuilder/SequencerNodeProperty.m
+++ b/CocosBuilder/ccBuilder/SequencerNodeProperty.m
@@ -202,7 +202,7 @@
         return NULL;
     }
     
-    if (numKeyframes == 1 && type == kCCBKeyframeTypeVisible)
+    if (numKeyframes == 1 && type == kCCBKeyframeTypeToggle)
     {
         SequencerKeyframe* keyframe = [keyframes objectAtIndex:0];
         return [NSNumber numberWithBool: (time >= keyframe.time)];
@@ -217,7 +217,7 @@
     SequencerKeyframe* keyframeFirst = [keyframes objectAtIndex:0];
     SequencerKeyframe* keyframeLast = [keyframes objectAtIndex:numKeyframes-1];
     
-    if (type == kCCBKeyframeTypeVisible)
+    if (type == kCCBKeyframeTypeToggle)
     {
         if (time < keyframeFirst.time)
         {
@@ -270,8 +270,8 @@
     SequencerKeyframe* keyframeStart = [keyframes objectAtIndex:startFrameNum];
     SequencerKeyframe* keyframeEnd = [keyframes objectAtIndex:endFrameNum];
     
-    // Skip interpolations for visiblity (special case)
-    if (type == kCCBKeyframeTypeVisible)
+    // Skip interpolations for toggle frames (special case)
+    if (type == kCCBKeyframeTypeToggle)
     {
         BOOL val = (startFrameNum % 2 == 0);
         return [NSNumber numberWithBool:val];

--- a/CocosBuilder/ccBuilder/SequencerScrubberSelectionView.m
+++ b/CocosBuilder/ccBuilder/SequencerScrubberSelectionView.m
@@ -316,8 +316,8 @@
     NSArray* props = node.plugIn.animatableProperties;
     
     NSString* prop = NULL;
-    if (sub == 0) prop = @"visible";
-    else prop = [props objectAtIndex:sub-1];
+
+    prop = [props objectAtIndex:sub];
     
     return prop;
 }

--- a/CocosBuilder/ccBuilder/SequencerStructureCell.m
+++ b/CocosBuilder/ccBuilder/SequencerStructureCell.m
@@ -56,7 +56,7 @@
         NSMutableDictionary* attrib = [NSMutableDictionary dictionary];
         [attrib setObject:style forKey:NSParagraphStyleAttributeName];
         [attrib setObject:textColor forKey:NSForegroundColorAttributeName];
-        
+        /*
         // Draw property names
         SequencerNodeProperty* seqNodeProp = [node sequenceNodeProperty:@"visible" sequenceId:seq.sequenceId];
         
@@ -78,12 +78,12 @@
         }
         
         [@"Visible" drawInRect:propNameRect withAttributes:attrib];
-        
+        */
         NSArray* props = node.plugIn.animatableProperties;
-        
+        int i=0;
         for (NSString* prop in props)
         {
-            seqNodeProp = [node sequenceNodeProperty:prop sequenceId:seq.sequenceId];
+            SequencerNodeProperty* seqNodeProp = [node sequenceNodeProperty:prop sequenceId:seq.sequenceId];
             BOOL hasKeyframes = ([seqNodeProp.keyframes count] > 0);
             
             if ([node shouldDisableProperty:prop])
@@ -106,8 +106,13 @@
             
             NSString* displayName = [[node.plugIn.nodePropertiesDict objectForKey:prop] objectForKey:@"displayName"];
             
-            propNameRect.origin.y += kCCBSeqDefaultRowHeight;
+            if (i>0)
+                propNameRect.origin.y += kCCBSeqDefaultRowHeight;
+            else
+                i++;
+            
             [displayName drawInRect:propNameRect withAttributes:attrib];
+            
         }
     
         // Leave space for property name when drawing name in super method


### PR DESCRIPTION
## Pull Request Summary

`type=Check` & `name=visible` don't share the same strong relationship anymore... they can start seeing other people, finally!
## Functionality Changes:
1. Any property within a plugin can be of type `Check`.
   When this property is also `animatable`, each keyframe acts as a _toggle switch_ for the property (exactly the same way as `Visible` keyframe is working already).
2. `Visible` property has to be animatable, otherwise it won't appear at the top row of the Timeline.
## Changes at Timeline's behaviour:
1. **Top row** displays the **first** `animatable` property of the Node.
2. **Sub rows** display the **rest** `animatable` properties.

It should be possible to create a custom Node Plug-in with any combination of animatable properties!
## Example:

Let's say I have a `CCNode` _subclass_ and I only want to animate its `X` value. 
I can now create a new Plug-In, override **all** `CCNode` properties to be `animatable = NO`, and add my `X` property as `animatable=YES`.

If I now use this Custom Plugin inside CocosBuilder, the _timeline_ will display **only one** row for it, which will _draw_ the keyframes for property `X`, no matter what the _type_ of `X` is.
## Notice

Code has been tested and it has been confirmed that `ccb` & `ccbi` files are read and written the same way as before (...what I mean is that I didn't notice any adverse effect).

If you Merge the Request, please **do confirm** that I didn't miss anything!

Thanks!
