### PR TITLE
CCLabelBMFont blend mode fix

### DIFF
--- a/CocosBuilder/CCLabelBMFont/CCBPProperties.plist
+++ b/CocosBuilder/CCLabelBMFont/CCBPProperties.plist
@@ -86,6 +86,11 @@
 			<string>color</string>
 		</dict>
 		<dict>
+			<key>default</key>
+			<array>
+				<integer>1</integer>
+				<integer>771</integer>
+			</array>
 			<key>defaultSerialization</key>
 			<array>
 				<integer>1</integer>


### PR DESCRIPTION
Fix for https://github.com/cocos2d/CocosBuilder/issues/191 : CCLabelBMFont was not using the same default blend mode for reading and writing.
