### PR TITLE
fix the build error of not finding CCSprite9Scale.h file.

### DIFF
--- a/CocosBuilder/ccBuilder/RulersLayer.h
+++ b/CocosBuilder/ccBuilder/RulersLayer.h
@@ -23,7 +23,7 @@
  */
 
 #import "cocos2d.h"
-#import "CCScale9Sprite.h"
+#import "CCControlExtension.h"
 
 @interface RulersLayer : CCLayer
 {


### PR DESCRIPTION
The CCSprite9Scale.h doesn't seem to be in the header search path, but
using the CCControlExtension.h fixes, as this header imports
CCSprite9Scale.h anyway.
