### PR TITLE
Fix build issue if path contain spaces

### DIFF
--- a/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
+++ b/CocosBuilder/CocosBuilder.xcodeproj/project.pbxproj
@@ -4517,7 +4517,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./../scripts/CopyBuiltProduct.sh $CONFIGURATION_BUILD_DIR/ $SRCROOT/../build/ $PRODUCT_NAME.app 1";
+			shellScript = "./../scripts/CopyBuiltProduct.sh \"$CONFIGURATION_BUILD_DIR/\" \"$SRCROOT/../build/\" \"$PRODUCT_NAME.app\" \"1\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Add quotes to CopyBuiltProduct.sh invocation to allow for spaces in the project path.

Previously was #256.
