### PR TITLE
Generated spritesheets are always square

### DIFF
--- a/CocosBuilder/libs/Tupac/Tupac.mm
+++ b/CocosBuilder/libs/Tupac/Tupac.mm
@@ -240,7 +240,7 @@ typedef struct _PVRTexHeader
     std::vector<TPRect> outRects;
     
     BOOL makeSquare = NO;
-    if (self.imageFormat == kTupacImageFormatPVRTC_2BPP || kTupacImageFormatPVRTC_4BPP)
+    if (self.imageFormat == kTupacImageFormatPVRTC_2BPP || self.imageFormat == kTupacImageFormatPVRTC_4BPP)
     {
         makeSquare = YES;
         outH = outW;


### PR DESCRIPTION
Fixed a logic bug that resulted in square spritesheet output in formats in which it is not necessary.
