### PR TITLE
HTML5 Template: Use runWithScene when loading first scene 

### DIFF
--- a/CocosBuilder/Resources/publishTemplates/main-html5.txt
+++ b/CocosBuilder/Resources/publishTemplates/main-html5.txt
@@ -24,7 +24,7 @@ var cocos2dApp = cc.Application.extend({
 
         //load resources
         cc.Loader.preload(ccb_resources, function () {
-            cc.Director.getInstance().replaceScene(new this.startScene());
+            cc.Director.getInstance().runWithScene(new this.startScene());
         }, this);
 
         return true;


### PR DESCRIPTION
Using runWithScene produces assertion error:

`Assertion failed: Use runWithScene: instead to start the director`
