### PR TITLE
Show and publish json files

### DIFF
--- a/CocosBuilder/ccBuilder/CCBPublisher.m
+++ b/CocosBuilder/ccBuilder/CCBPublisher.m
@@ -57,7 +57,7 @@
     warnings = [w retain];
     
     // Setup extensions to copy
-    copyExtensions = [[NSArray alloc] initWithObjects:@"jpg",@"png", @"pvr", @"ccz", @"plist", @"fnt", @"ttf",@"js",@"wav",@"mp3",@"m4a",@"caf", nil];
+    copyExtensions = [[NSArray alloc] initWithObjects:@"jpg",@"png", @"pvr", @"ccz", @"plist", @"fnt", @"ttf",@"js", @"json", @"wav",@"mp3",@"m4a",@"caf", nil];
     
     // Set format to use for exports
     self.publishFormat = projectSettings.exporter;

--- a/CocosBuilder/ccBuilder/ResourceManager.h
+++ b/CocosBuilder/ccBuilder/ResourceManager.h
@@ -39,6 +39,7 @@ enum
     kCCBResTypeTTF,
     kCCBResTypeCCBFile,
     kCCBResTypeJS,
+    kCCBResTypeJSON,
     kCCBResTypeAudio,
     kCCBResTypeGeneratedSpriteSheetDef,
 };

--- a/CocosBuilder/ccBuilder/ResourceManager.m
+++ b/CocosBuilder/ccBuilder/ResourceManager.m
@@ -465,6 +465,10 @@
     {
         return kCCBResTypeJS;
     }
+    else if ([ext isEqualToString:@"json"])
+    {
+        return kCCBResTypeJSON;
+    }
     else if ([ext isEqualToString:@"wav"]
              || [ext isEqualToString:@"mp3"]
              || [ext isEqualToString:@"m4a"]
@@ -685,6 +689,7 @@
                 || res.type == kCCBResTypeCCBFile
                 || res.type == kCCBResTypeDirectory
                 || res.type == kCCBResTypeJS
+                || res.type == kCCBResTypeJSON
                 || res.type == kCCBResTypeAudio)
             {
                 [dir.any addObject:res];

--- a/CocosBuilder/ccBuilder/ResourceManagerOutlineHandler.m
+++ b/CocosBuilder/ccBuilder/ResourceManagerOutlineHandler.m
@@ -390,7 +390,7 @@
         {
             [[CocosBuilderAppDelegate appDelegate] openFile: res.filePath];
         }
-        else if (res.type == kCCBResTypeJS)
+        else if (res.type == kCCBResTypeJS || res.type == kCCBResTypeJSON)
         {
             [[CocosBuilderAppDelegate appDelegate] openJSFile:res.filePath];
         }


### PR DESCRIPTION
JSON files can be used for configuring app. Currently, CocosBuilders ignores files with *.json extension in resource panel and during publishing. This pull request fixes it.
