### PR TITLE
Added "Line Break Mode" option to CCLabelTTF

### DIFF
--- a/CocosBuilder/CCLabelTTF/CCBPProperties.plist
+++ b/CocosBuilder/CCLabelTTF/CCBPProperties.plist
@@ -130,6 +130,16 @@
 			<string>Top|0|Center|1|Bottom|2</string>
 		</dict>
 		<dict>
+			<key>displayName</key>
+			<string>Line Break Mode</string>
+			<key>type</key>
+			<string>IntegerLabeled</string>
+			<key>name</key>
+			<string>lineBreakMode</string>
+			<key>extra</key>
+			<string>kCCLineBreakModeWordWrap|0|kCCLineBreakModeCharacterWrap|1|kCCLineBreakModeClip|2|kCCLineBreakModeHeadTruncation|3|kCCLineBreakModeTailTruncation|4|kCCLineBreakModeMiddleTruncation|5</string>
+		</dict>
+		<dict>
 			<key>affectsProperties</key>
 			<array>
 				<string>contentSize</string>


### PR DESCRIPTION
Hey,
I noticed that you are missing the Line Break Mode option on CCLabelTTF, so I added it.
Btw. thanks for such amazing tool! :+1: 
