### PR TITLE
Fix "too many directories" error 

### DIFF
--- a/CocosBuilder/ccBuilder/ResourceManager.h
+++ b/CocosBuilder/ccBuilder/ResourceManager.h
@@ -26,7 +26,7 @@
 #import "SCEvents.h"
 #import "SCEvent.h"
 
-#define kCCBMaxTrackedDirectories 50
+#define kCCBMaxTrackedDirectories 5000
 
 enum
 {


### PR DESCRIPTION
Hi, we developing large game. And this is very useful tool. Awesome! I'd like to shake your hand.

In the case of developing large game, this "too many directories" error is one of big issue in use of cocosbuilder.
Basically, in large game needs many images. many images need many directories.

So, we look forward to fix for so long.

thanks.
