### PR TITLE
Fixed the issue when trying to access submodules:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "CocosBuilder/libs/cocos2d-iphone"]
 	path = CocosBuilder/libs/cocos2d-iphone
-	url = https://github.com/cocos2d/cocos2d-iphone.git
+	url = git://github.com/cocos2d/cocos2d-iphone-classic.git
 [submodule "CocosBuilder/libs/ssziparchive"]
 	path = CocosBuilder/libs/ssziparchive
-	url = https://github.com/vlidholt/ssziparchive
+	url = git://github.com/vlidholt/ssziparchive
 [submodule "CocosBuilder/libs/Fragaria"]
 	path = CocosBuilder/libs/Fragaria
-	url = https://github.com/vlidholt/Fragaria.git
+	url = git://github.com/vlidholt/Fragaria.git
 [submodule "Examples/CocosBuilderExample/libs/CCBReader"]
 	path = Examples/CocosBuilderExample/libs/CCBReader
 	url = git://github.com/cocos2d/CCBReader.git


### PR DESCRIPTION
$ git submodule update --init --recursive
fatal: reference is not a tree: b51de15acb37d72719b03314771e4caa04e57a33
Unable to checkout 'b51de15acb37d72719b03314771e4caa04e57a33' in submodule path 'CocosBuilder/libs/cocos2d-iphone'

There is a multi-step process in order to make this work (detached HEAD) with the latest for tag “release-1.1-RC0”
